### PR TITLE
Implementing SQL log statements using DataSource-Proxy

### DIFF
--- a/kafka-consumer-demo/pom.xml
+++ b/kafka-consumer-demo/pom.xml
@@ -51,6 +51,13 @@
             <groupId>org.springframework</groupId>
             <artifactId>spring-jdbc</artifactId>
         </dependency>
+
+        <!-- DataSource-Proxy for printing SQL statements -->
+        <dependency>
+            <groupId>com.github.gavlyukovskiy</groupId>
+            <artifactId>datasource-proxy-spring-boot-starter</artifactId>
+            <version>1.9.1</version>
+        </dependency>
     </dependencies>
 
 </project>

--- a/kafka-consumer-demo/src/main/resources/application.properties
+++ b/kafka-consumer-demo/src/main/resources/application.properties
@@ -21,6 +21,7 @@ management.observations.key-values.some.tag=some.value
 # logging.pattern.level=%5p [${spring.application.name:},%X{traceId:-},%X{spanId:-}]
 #exmaple of log level configuration by Class
 logging.level.com.example.messaging.controller.FactController=INFO
+logging.level.net.ttddyy.dsproxy.listener=DEBUG
 #logging.level.io.micrometer=TRACE
 #logging.level.io.opentelemetry=TRACE
 # Database configuration


### PR DESCRIPTION
- Using DataSource-Proxy to log SQL statements. Below you will see an example of the log format of an insert query performed by the kafka consumer

`2024-01-10T11:05:12.694-03:00 DEBUG 4593 --- [kafka-consumer-demo] [ntainer#0-0-C-1] [80b3ee576bb93fd6a94cb78e15ca3614-b7f2d28dd1bbf52a] n.t.d.l.l.SLF4JQueryLoggingListener      : 
Name:dataSource, Connection:5, Time:7, Success:True
Type:Prepared, Batch:False, QuerySize:1, BatchSize:0
Query:["insert into fact (fact,id) values (?,?)"]
Params:[(All arrays Chuck Norris declares are of infinite size, because Chuck Norris knows no bounds.,976841)]`

- Using DataSource-Proxy is a better option than setting show-sql=true because it will not log SQL statements as System.out.println and we can easily see the parameters informed to the query

- Apparently we don't have a log format defined to this application. Perhaps, creating another task to think about this definition can be good